### PR TITLE
Add analyzer page for running sample parts through Zen rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist
 *.tgz
 public/editor.js
 public/editor.css
+public/analyze.js
+public/analyze.css
 
 # code coverage
 coverage

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ data using Zen Engine.
   demonstrates a switch node for international logic and JavaScript functions
   for both base rate and error‑tolerant cost calculation. It can load existing
   rules and publish updates to a local SQLite database.
-- `GET /analyze` – interactive page to generate sample parts (including
-  `origin_country`) and run them through a ruleset via Zen Engine. The analyzer
-  inspects the rule's input fields to prefill compatible part properties.
+- `GET /analyze` – interactive page to define property ranges, generate sample
+  parts (including `origin_country`), and run them through a ruleset via Zen
+  Engine. The analyzer inspects the rule's input fields to prefill compatible
+  part properties.
 - `POST /rulesets` – backend endpoint used by the editor to save rules. Versions
   are automatically incremented.
 - `GET /rules` – list all available rule IDs.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ serves JSON Decision Model (JDM) rules using [GoRules Zen Engine](https://gorule
 The `/editor` endpoint hosts the React-based
 [`@gorules/jdm-editor`](https://github.com/gorules/jdm-editor) component to
 craft JDM documents in the browser and publish them to a local SQLite database.
+The `/analyze` endpoint showcases executing the rules against generated test
+data using Zen Engine.
 
 ## Endpoints
 
 - `GET /editor` – React JDM editor prefilled with a sample shipping rule. It can
   load existing rules and publish updates to a local SQLite database.
+- `GET /analyze` – interactive page to generate sample parts and run them
+  through a ruleset via Zen Engine.
 - `POST /rulesets` – backend endpoint used by the editor to save rules. Versions
   are automatically incremented.
 - `GET /rules` – list all available rule IDs.
@@ -22,10 +26,11 @@ craft JDM documents in the browser and publish them to a local SQLite database.
 
 ```bash
 bun install
-bun run build:editor   # build React editor assets
+bun run build:editor   # build frontend assets
 bun run index.ts
 ```
 
-The server listens on <http://localhost:3000>. Opening `/editor` in the browser
-loads the full-featured JDM editor that can publish rules to the backend.
+The server listens on <http://localhost:3000>. Opening `/editor` loads the
+JDM editor while `/analyze` allows running generated data through the rules
+engine.
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ data using Zen Engine.
 ## Endpoints
 
 - `GET /editor` – React JDM editor prefilled with a sample shipping rule that
-  demonstrates a decision table for weight-based base rates, a switch node for
-  international logic and a JavaScript function for error‑tolerant cost
-  calculation. It can load existing rules and publish updates to a local SQLite
-  database.
+  demonstrates a switch node for international logic and JavaScript functions
+  for both base rate and error‑tolerant cost calculation. It can load existing
+  rules and publish updates to a local SQLite database.
 - `GET /analyze` – interactive page to generate sample parts (including
   `origin_country`) and run them through a ruleset via Zen Engine. The analyzer
   inspects the rule's input fields to prefill compatible part properties.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ data using Zen Engine.
 
 ## Endpoints
 
-- `GET /editor` – React JDM editor prefilled with a sample shipping rule that
-  demonstrates a switch node for international logic, expression nodes for
-  base rate and tariff calculations, and a JavaScript function for the
-  error‑tolerant total cost. It can load existing rules and publish updates to a
-  local SQLite database.
+- `GET /editor` – React JDM editor prefilled with a sample shipping rule using
+  expression nodes to compute base rates, tariffs, and totals from each part’s
+  weight, cost, and origin country. It can load existing rules and publish
+  updates to a local SQLite database.
 - `GET /analyze` – interactive page to define property ranges, generate sample
   parts (including `origin_country`), and run them through a ruleset via Zen
   Engine. The analyzer inspects the rule's input fields to prefill compatible

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ data using Zen Engine.
 ## Endpoints
 
 - `GET /editor` – React JDM editor prefilled with a sample shipping rule that
-  demonstrates a switch node for international logic and JavaScript functions
-  for both base rate and error‑tolerant cost calculation. It can load existing
-  rules and publish updates to a local SQLite database.
+  demonstrates a switch node for international logic, expression nodes for
+  base rate and tariff calculations, and a JavaScript function for the
+  error‑tolerant total cost. It can load existing rules and publish updates to a
+  local SQLite database.
 - `GET /analyze` – interactive page to define property ranges, generate sample
   parts (including `origin_country`), and run them through a ruleset via Zen
   Engine. The analyzer inspects the rule's input fields to prefill compatible

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ data using Zen Engine.
 ## Endpoints
 
 - `GET /editor` – React JDM editor prefilled with a sample shipping rule that
-  computes a weight-based tariff and adds a cost surcharge. It can load existing
-  rules and publish updates to a local SQLite database.
-- `GET /analyze` – interactive page to generate sample parts and run them
-  through a ruleset via Zen Engine. The analyzer inspects the rule's input
-  fields to prefill compatible part properties.
+  demonstrates a decision table for weight-based base rates, a switch node for
+  international logic and a JavaScript function for error‑tolerant cost
+  calculation. It can load existing rules and publish updates to a local SQLite
+  database.
+- `GET /analyze` – interactive page to generate sample parts (including
+  `origin_country`) and run them through a ruleset via Zen Engine. The analyzer
+  inspects the rule's input fields to prefill compatible part properties.
 - `POST /rulesets` – backend endpoint used by the editor to save rules. Versions
   are automatically incremented.
 - `GET /rules` – list all available rule IDs.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ data using Zen Engine.
 
 ## Endpoints
 
-- `GET /editor` – React JDM editor prefilled with a sample shipping rule. It can
-  load existing rules and publish updates to a local SQLite database.
+- `GET /editor` – React JDM editor prefilled with a sample shipping rule that
+  computes a weight-based tariff and adds a cost surcharge. It can load existing
+  rules and publish updates to a local SQLite database.
 - `GET /analyze` – interactive page to generate sample parts and run them
   through a ruleset via Zen Engine. The analyzer inspects the rule's input
   fields to prefill compatible part properties.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ data using Zen Engine.
 - `GET /editor` – React JDM editor prefilled with a sample shipping rule. It can
   load existing rules and publish updates to a local SQLite database.
 - `GET /analyze` – interactive page to generate sample parts and run them
-  through a ruleset via Zen Engine.
+  through a ruleset via Zen Engine. The analyzer inspects the rule's input
+  fields to prefill compatible part properties.
 - `POST /rulesets` – backend endpoint used by the editor to save rules. Versions
   are automatically incremented.
 - `GET /rules` – list all available rule IDs.

--- a/analyze.tsx
+++ b/analyze.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+interface PropDef {
+  name: string;
+  min: number;
+  max: number;
+}
+
+const App = () => {
+  const [rule, setRule] = useState('shipping@latest');
+  const [count, setCount] = useState(5);
+  const [props, setProps] = useState<PropDef[]>([{ name: 'weight', min: 1, max: 10 }]);
+  const [parts, setParts] = useState<any[]>([]);
+  const [results, setResults] = useState<any[]>([]);
+
+  const updateProp = (index: number, field: keyof PropDef, value: any) => {
+    setProps((prev) => prev.map((p, i) => (i === index ? { ...p, [field]: value } : p)));
+  };
+
+  const addProp = () => setProps((p) => [...p, { name: '', min: 0, max: 0 }]);
+  const removeProp = (index: number) => setProps((p) => p.filter((_, i) => i !== index));
+
+  const generate = () => {
+    const arr = Array.from({ length: count }, () => {
+      const obj: any = {};
+      for (const p of props) {
+        const val = p.min + Math.random() * (p.max - p.min);
+        obj[p.name] = Number(val.toFixed(2));
+      }
+      return obj;
+    });
+    setParts(arr);
+    setResults([]);
+  };
+
+  const analyze = async () => {
+    const res = await fetch('/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: rule, parts })
+    });
+    const data = await res.json();
+    setResults(data);
+  };
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
+      <h2>Zen Engine Analyzer</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <label>
+          Rule Key:&nbsp;
+          <input value={rule} onChange={(e) => setRule(e.target.value)} />
+        </label>
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <label>
+          Part Count:&nbsp;
+          <input
+            type="number"
+            value={count}
+            min={1}
+            onChange={(e) => setCount(Number(e.target.value))}
+            style={{ width: '4rem' }}
+          />
+        </label>
+      </div>
+      <div>
+        <h4>Properties</h4>
+        {props.map((p, i) => (
+          <div key={i} style={{ marginBottom: '0.5rem' }}>
+            <input
+              placeholder="name"
+              value={p.name}
+              onChange={(e) => updateProp(i, 'name', e.target.value)}
+              style={{ width: '6rem' }}
+            />
+            <input
+              type="number"
+              value={p.min}
+              onChange={(e) => updateProp(i, 'min', Number(e.target.value))}
+              style={{ width: '5rem', marginLeft: '0.5rem' }}
+            />
+            <input
+              type="number"
+              value={p.max}
+              onChange={(e) => updateProp(i, 'max', Number(e.target.value))}
+              style={{ width: '5rem', marginLeft: '0.5rem' }}
+            />
+            <button onClick={() => removeProp(i)} style={{ marginLeft: '0.5rem' }}>
+              x
+            </button>
+          </div>
+        ))}
+        <button onClick={addProp}>Add Property</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={generate}>Generate Parts</button>
+      </div>
+      {parts.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h4>Generated Parts</h4>
+          <pre>{JSON.stringify(parts, null, 2)}</pre>
+          <button onClick={analyze}>Run Analysis</button>
+        </div>
+      )}
+      {results.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h4>Results</h4>
+          <table border={1} cellPadding={4}>
+            <thead>
+              <tr>
+                <th>Input</th>
+                <th>Output</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r, i) => (
+                <tr key={i}>
+                  <td>
+                    <pre>{JSON.stringify(parts[i], null, 2)}</pre>
+                  </td>
+                  <td>
+                    <pre>{JSON.stringify(r, null, 2)}</pre>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/analyze.tsx
+++ b/analyze.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 
 interface PropDef {
@@ -20,6 +20,28 @@ const App = () => {
 
   const addProp = () => setProps((p) => [...p, { name: '', min: 0, max: 0 }]);
   const removeProp = (index: number) => setProps((p) => p.filter((_, i) => i !== index));
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch(`/rules/${encodeURIComponent(rule)}`);
+        if (!res.ok) return;
+        const jdm = await res.json();
+        const input = jdm.nodes?.find((n: any) => n.type === 'inputNode');
+        if (input?.content?.fields?.length) {
+          setProps(
+            input.content.fields.map((f: any) => ({
+              name: f.key || f.name,
+              min: 0,
+              max: 10
+            }))
+          );
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, [rule]);
 
   const generate = () => {
     const arr = Array.from({ length: count }, () => {

--- a/analyze.tsx
+++ b/analyze.tsx
@@ -10,7 +10,10 @@ interface PropDef {
 const App = () => {
   const [rule, setRule] = useState('shipping@latest');
   const [count, setCount] = useState(5);
-  const [props, setProps] = useState<PropDef[]>([{ name: 'weight', min: 1, max: 10 }]);
+  const [props, setProps] = useState<PropDef[]>([
+    { name: 'weight', min: 1, max: 10 },
+    { name: 'cost', min: 10, max: 100 }
+  ]);
   const [parts, setParts] = useState<any[]>([]);
   const [results, setResults] = useState<any[]>([]);
 

--- a/editor.tsx
+++ b/editor.tsx
@@ -15,16 +15,34 @@ const exampleGraph: DecisionGraphType = {
       name: 'Start',
       position: { x: 100, y: 100 },
       content: {
-        fields: [{ id: 'f1', key: 'cost', type: 'number', name: 'Cost' }],
+        fields: [
+          { id: 'f1', key: 'weight', type: 'number', name: 'Weight' },
+          { id: 'f2', key: 'cost', type: 'number', name: 'Cost' }
+        ]
+      },
+    },
+    {
+      id: 'tariff',
+      type: 'expressionNode',
+      name: 'Tariff',
+      position: { x: 400, y: 100 },
+      content: {
+        expressions: [{ id: 'exp1', key: 'tariff', value: 'weight * 0.05' }],
+        passThrough: true,
+        inputField: null,
+        outputPath: null,
+        executionMode: 'single',
       },
     },
     {
       id: 'cost',
       type: 'expressionNode',
       name: 'Shipping cost',
-      position: { x: 400, y: 100 },
+      position: { x: 700, y: 100 },
       content: {
-        expressions: [{ id: 'exp1', key: 'shippingCost', value: 'cost * 0.1' }],
+        expressions: [
+          { id: 'exp2', key: 'shippingCost', value: 'cost * 0.1 + tariff' }
+        ],
         passThrough: false,
         inputField: null,
         outputPath: null,
@@ -35,13 +53,14 @@ const exampleGraph: DecisionGraphType = {
       id: 'output',
       type: 'outputNode',
       name: 'Result',
-      position: { x: 700, y: 100 },
+      position: { x: 1000, y: 100 },
       content: {},
     },
   ],
   edges: [
-    { id: 'e1', type: 'edge', sourceId: 'start', targetId: 'cost' },
-    { id: 'e2', type: 'edge', sourceId: 'cost', targetId: 'output' },
+    { id: 'e1', type: 'edge', sourceId: 'start', targetId: 'tariff' },
+    { id: 'e2', type: 'edge', sourceId: 'tariff', targetId: 'cost' },
+    { id: 'e3', type: 'edge', sourceId: 'cost', targetId: 'output' },
   ],
 };
 

--- a/editor.tsx
+++ b/editor.tsx
@@ -15,7 +15,7 @@ const exampleGraph: DecisionGraphType = {
       name: 'Start',
       position: { x: 100, y: 100 },
       content: {
-        fields: [{ id: 'f1', key: 'weight', type: 'number', name: 'Weight' }],
+        fields: [{ id: 'f1', key: 'cost', type: 'number', name: 'Cost' }],
       },
     },
     {
@@ -24,7 +24,7 @@ const exampleGraph: DecisionGraphType = {
       name: 'Shipping cost',
       position: { x: 400, y: 100 },
       content: {
-        expressions: [{ id: 'exp1', key: 'shippingCost', value: 'weight * 1.5' }],
+        expressions: [{ id: 'exp1', key: 'shippingCost', value: 'cost * 0.1' }],
         passThrough: false,
         inputField: null,
         outputPath: null,

--- a/editor.tsx
+++ b/editor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
   DecisionGraph,
@@ -111,6 +111,7 @@ const clone = <T,>(val: T): T => structuredClone(val);
 
 const App = () => {
   const [graph, setGraph] = useState<DecisionGraphType | undefined>(clone(exampleGraph));
+  const memoGraph = useMemo(() => (graph ? clone(graph) : graph), [graph]);
   const [id, setId] = useState('shipping');
   const [status, setStatus] = useState('draft');
   const [version, setVersion] = useState('');
@@ -139,7 +140,7 @@ const App = () => {
   return (
     <JdmConfigProvider>
       <div style={{ height: '80vh' }}>
-        <DecisionGraph value={graph} onChange={(val) => setGraph(clone(val as any))} />
+        <DecisionGraph value={memoGraph} onChange={(val) => setGraph(clone(val as any))} />
       </div>
       <div
         style={{

--- a/editor.tsx
+++ b/editor.tsx
@@ -14,59 +14,35 @@ const exampleGraph: DecisionGraphType = {
       type: 'inputNode',
       name: 'Start',
       position: { x: 100, y: 100 },
-      content: {}
-    },
-    {
-      id: 'tariff',
-      type: 'expressionNode',
-      name: 'Calc tariff',
-      position: { x: 400, y: 100 },
       content: {
-        expressions: [
-          {
-            id: 'exp1',
-            key: 'tariff',
-            value: 'input.weight * 0.05'
-          }
-        ],
-        passThrough: false,
-        inputField: null,
-        outputPath: null,
-        executionMode: 'single'
-      }
+        fields: [{ id: 'f1', key: 'weight', type: 'number', name: 'Weight' }],
+      },
     },
     {
       id: 'cost',
       type: 'expressionNode',
       name: 'Shipping cost',
-      position: { x: 700, y: 100 },
+      position: { x: 400, y: 100 },
       content: {
-        expressions: [
-          {
-            id: 'exp2',
-            key: 'shippingCost',
-            value: 'input.weight * 1.5 + tariff'
-          }
-        ],
+        expressions: [{ id: 'exp1', key: 'shippingCost', value: 'weight * 1.5' }],
         passThrough: false,
         inputField: null,
         outputPath: null,
-        executionMode: 'single'
-      }
+        executionMode: 'single',
+      },
     },
     {
       id: 'output',
       type: 'outputNode',
       name: 'Result',
-      position: { x: 1000, y: 100 },
-      content: {}
-    }
+      position: { x: 700, y: 100 },
+      content: {},
+    },
   ],
   edges: [
-    { id: 'e1', type: 'edge', sourceId: 'start', targetId: 'tariff' },
-    { id: 'e2', type: 'edge', sourceId: 'tariff', targetId: 'cost' },
-    { id: 'e3', type: 'edge', sourceId: 'cost', targetId: 'output' }
-  ]
+    { id: 'e1', type: 'edge', sourceId: 'start', targetId: 'cost' },
+    { id: 'e2', type: 'edge', sourceId: 'cost', targetId: 'output' },
+  ],
 };
 
 const App = () => {

--- a/editor.tsx
+++ b/editor.tsx
@@ -33,13 +33,23 @@ const exampleGraph: DecisionGraphType = {
       id: 'base',
       type: 'expressionNode',
       name: 'Base Rate',
-      position: { x: 400, y: 100 },
+      position: { x: 340, y: 100 },
       content: {
         expressions: [
           {
             id: 'e1',
             key: 'base',
             value: 'weight <= 5 ? 5 : weight <= 10 ? 8 : 12'
+          },
+          {
+            id: 'b9333d19-ad3b-4c76-a623-f8ab9fe863b1',
+            key: 'tariff_rate',
+            value: "origin_country != 'US' ? origin_country == 'CN' ? 0.3 : 0.15 : 0"
+          },
+          {
+            id: '35c7209d-6ef7-4f3f-b245-cab68a733dc4',
+            key: '',
+            value: ''
           }
         ],
         passThrough: true,
@@ -49,26 +59,23 @@ const exampleGraph: DecisionGraphType = {
       }
     },
     {
-      id: 'intl',
-      type: 'switchNode',
-      name: 'International?',
-      position: { x: 700, y: 100 },
-      content: {
-        hitPolicy: 'first',
-        statements: [
-          { id: 's1', condition: "origin_country != 'US'", isDefault: false },
-          { id: 's2', condition: '', isDefault: true }
-        ]
-      }
-    },
-    {
       id: 'tariff',
       type: 'expressionNode',
       name: 'Tariff',
-      position: { x: 1000, y: 40 },
+      position: { x: 580, y: 100 },
       content: {
         expressions: [
-          { id: 'e1', key: 'tariff', value: 'cost * 0.15' }
+          {
+            id: 'e332633e-044b-4c16-94e4-0c670817f755',
+            key: 'shipping',
+            value: 'base + weight * 2'
+          },
+          { id: 'e1', key: 'tariff', value: 'cost * tariff_rate' },
+          {
+            id: '45e10f1b-f273-4eb2-b07e-ad170b368dd2',
+            key: 'total',
+            value: '(weight * 5) + cost * (1 + tariff_rate)'
+          }
         ],
         passThrough: true,
         inputField: null,
@@ -77,39 +84,34 @@ const exampleGraph: DecisionGraphType = {
       }
     },
     {
-      id: 'total',
-      type: 'functionNode',
-      name: 'Total Cost',
-      position: { x: 1000, y: 180 },
-      content: {
-        source: `export default ({ cost, base, tariff }) => {
-  const total = Number(base) + cost * 0.1 + (tariff || 0);
-  const res = { shippingCost: total };
-  if (tariff) res.tariff = tariff;
-  return res;
-}`
-      }
-    },
-    {
       id: 'output',
       type: 'outputNode',
       name: 'Result',
-      position: { x: 1300, y: 100 },
+      position: { x: 865, y: 100 },
       content: {}
     }
   ],
   edges: [
     { id: 'e1', type: 'edge', sourceId: 'start', targetId: 'base' },
-    { id: 'e2', type: 'edge', sourceId: 'base', targetId: 'intl' },
-    { id: 'e3', type: 'edge', sourceId: 'intl', sourceHandle: 's1', targetId: 'tariff' },
-    { id: 'e4', type: 'edge', sourceId: 'tariff', targetId: 'total' },
-    { id: 'e5', type: 'edge', sourceId: 'intl', sourceHandle: 's2', targetId: 'total' },
-    { id: 'e6', type: 'edge', sourceId: 'total', targetId: 'output' }
+    {
+      id: '7dfe0558-aeb3-4b11-8bfd-85451378c501',
+      sourceId: 'base',
+      type: 'edge',
+      targetId: 'tariff'
+    },
+    {
+      id: '3f83a9de-7650-4d11-bcf6-5362186cd188',
+      sourceId: 'tariff',
+      type: 'edge',
+      targetId: 'output'
+    }
   ]
 };
 
 const App = () => {
-  const [graph, setGraph] = useState<DecisionGraphType | undefined>(clone(exampleGraph));
+  const [graph, setGraph] = useState<DecisionGraphType | undefined>(
+    clone(exampleGraph)
+  );
   const [id, setId] = useState('shipping');
   const [status, setStatus] = useState('draft');
   const [version, setVersion] = useState('');

--- a/editor.tsx
+++ b/editor.tsx
@@ -31,22 +31,11 @@ const exampleGraph: DecisionGraphType = {
     },
     {
       id: 'base',
-      type: 'decisionTableNode',
+      type: 'functionNode',
       name: 'Base Rate',
       position: { x: 400, y: 100 },
       content: {
-        hitPolicy: 'first',
-        rules: [
-          { i1: '< 5', o1: '5' },
-          { i1: '[5..10]', o1: '8' },
-          { i1: '> 10', o1: '12' }
-        ],
-        inputs: [{ id: 'i1', name: 'Weight', field: 'weight' }],
-        outputs: [{ id: 'o1', name: 'Base', field: 'base' }],
-        passThrough: true,
-        inputField: null,
-        outputPath: null,
-        executionMode: 'single'
+        source: `({ weight }) => ({ base: weight <= 5 ? 5 : weight <= 10 ? 8 : 12 })`
       }
     },
     {

--- a/editor.tsx
+++ b/editor.tsx
@@ -31,11 +31,21 @@ const exampleGraph: DecisionGraphType = {
     },
     {
       id: 'base',
-      type: 'functionNode',
+      type: 'expressionNode',
       name: 'Base Rate',
       position: { x: 400, y: 100 },
       content: {
-        source: `({ weight }) => ({ base: weight <= 5 ? 5 : weight <= 10 ? 8 : 12 })`
+        expressions: [
+          {
+            id: 'e1',
+            key: 'base',
+            value: 'weight <= 5 ? 5 : weight <= 10 ? 8 : 12'
+          }
+        ],
+        passThrough: true,
+        inputField: null,
+        outputPath: null,
+        executionMode: 'single'
       }
     },
     {
@@ -53,11 +63,17 @@ const exampleGraph: DecisionGraphType = {
     },
     {
       id: 'tariff',
-      type: 'functionNode',
+      type: 'expressionNode',
       name: 'Tariff',
       position: { x: 1000, y: 40 },
       content: {
-        source: `({ cost }) => ({ tariff: cost * 0.15 })`
+        expressions: [
+          { id: 'e1', key: 'tariff', value: 'cost * 0.15' }
+        ],
+        passThrough: true,
+        inputField: null,
+        outputPath: null,
+        executionMode: 'single'
       }
     },
     {
@@ -66,15 +82,11 @@ const exampleGraph: DecisionGraphType = {
       name: 'Total Cost',
       position: { x: 1000, y: 180 },
       content: {
-        source: `({ cost, base, tariff }) => {
-  try {
-    const total = Number(base) + cost * 0.1 + (tariff || 0);
-    const res = { shippingCost: total };
-    if (tariff) res.tariff = tariff;
-    return res;
-  } catch (err) {
-    return { error: err.message };
-  }
+        source: `export default ({ cost, base, tariff }) => {
+  const total = Number(base) + cost * 0.1 + (tariff || 0);
+  const res = { shippingCost: total };
+  if (tariff) res.tariff = tariff;
+  return res;
 }`
       }
     },

--- a/editor.tsx
+++ b/editor.tsx
@@ -7,6 +7,8 @@ import {
 } from '@gorules/jdm-editor';
 import '@gorules/jdm-editor/dist/style.css';
 
+const clone = <T,>(val: T): T => JSON.parse(JSON.stringify(val));
+
 const exampleGraph: DecisionGraphType = {
   nodes: [
     {
@@ -40,7 +42,11 @@ const exampleGraph: DecisionGraphType = {
           { i1: '> 10', o1: '12' }
         ],
         inputs: [{ id: 'i1', name: 'Weight', field: 'weight' }],
-        outputs: [{ id: 'o1', name: 'Base', field: 'base' }]
+        outputs: [{ id: 'o1', name: 'Base', field: 'base' }],
+        passThrough: true,
+        inputField: null,
+        outputPath: null,
+        executionMode: 'single'
       }
     },
     {
@@ -102,7 +108,7 @@ const exampleGraph: DecisionGraphType = {
 };
 
 const App = () => {
-  const [graph, setGraph] = useState<DecisionGraphType | undefined>(exampleGraph);
+  const [graph, setGraph] = useState<DecisionGraphType | undefined>(clone(exampleGraph));
   const [id, setId] = useState('shipping');
   const [status, setStatus] = useState('draft');
   const [version, setVersion] = useState('');
@@ -121,7 +127,7 @@ const App = () => {
     const res = await fetch(`/rules/${encodeURIComponent(key)}`);
     if (res.ok) {
       const data = await res.json();
-      setGraph(data as any);
+      setGraph(clone(data as any));
       alert('Rule loaded');
     } else {
       alert('Rule not found');
@@ -131,7 +137,7 @@ const App = () => {
   return (
     <JdmConfigProvider>
       <div style={{ height: '80vh' }}>
-        <DecisionGraph value={graph} onChange={(val) => setGraph(val as any)} />
+        <DecisionGraph value={graph} onChange={(val) => setGraph(clone(val as any))} />
       </div>
       <div
         style={{

--- a/editor.tsx
+++ b/editor.tsx
@@ -14,7 +14,7 @@ const exampleGraph: DecisionGraphType = {
       type: 'inputNode',
       name: 'Start',
       position: { x: 100, y: 100 },
-      content: null
+      content: {}
     },
     {
       id: 'tariff',
@@ -26,7 +26,7 @@ const exampleGraph: DecisionGraphType = {
           {
             id: 'exp1',
             key: 'tariff',
-            value: "input.country !== 'US' ? input.value * 0.05 : 0"
+            value: 'input.weight * 0.05'
           }
         ],
         passThrough: false,
@@ -59,7 +59,7 @@ const exampleGraph: DecisionGraphType = {
       type: 'outputNode',
       name: 'Result',
       position: { x: 1000, y: 100 },
-      content: null
+      content: {}
     }
   ],
   edges: [

--- a/editor.tsx
+++ b/editor.tsx
@@ -107,7 +107,11 @@ const exampleGraph: DecisionGraphType = {
   ]
 };
 
-const clone = <T,>(val: T): T => structuredClone(val);
+// Immer freezes the graph before passing it back via `onChange`, which makes
+// subsequent edits to the same object throw "object is not extensible" errors
+// inside the JDM editor. A JSON round‑trip ensures we always hand the editor a
+// fully mutable copy of the graph and strip any frozen property descriptors.
+const clone = <T,>(val: T): T => JSON.parse(JSON.stringify(val));
 
 const App = () => {
   const [graph, setGraph] = useState<DecisionGraphType | undefined>(clone(exampleGraph));

--- a/editor.tsx
+++ b/editor.tsx
@@ -107,8 +107,10 @@ const exampleGraph: DecisionGraphType = {
   ]
 };
 
+const clone = <T,>(val: T): T => structuredClone(val);
+
 const App = () => {
-  const [graph, setGraph] = useState<DecisionGraphType | undefined>(exampleGraph);
+  const [graph, setGraph] = useState<DecisionGraphType | undefined>(clone(exampleGraph));
   const [id, setId] = useState('shipping');
   const [status, setStatus] = useState('draft');
   const [version, setVersion] = useState('');
@@ -127,7 +129,7 @@ const App = () => {
     const res = await fetch(`/rules/${encodeURIComponent(key)}`);
     if (res.ok) {
       const data = await res.json();
-      setGraph(data as any);
+      setGraph(clone(data as any));
       alert('Rule loaded');
     } else {
       alert('Rule not found');
@@ -137,7 +139,7 @@ const App = () => {
   return (
     <JdmConfigProvider>
       <div style={{ height: '80vh' }}>
-        <DecisionGraph value={graph} onChange={(val) => setGraph(val as any)} />
+        <DecisionGraph value={graph} onChange={(val) => setGraph(clone(val as any))} />
       </div>
       <div
         style={{

--- a/index.ts
+++ b/index.ts
@@ -28,7 +28,15 @@ const loadJdm = async (key: string) => {
       .get(id, Number(ver)) as any;
   }
   if (!row) throw new Error(`JDM not found for ${key}`);
-  return Buffer.from(row.jdm, 'utf8');
+  const jdm = JSON.parse(row.jdm);
+  if (Array.isArray(jdm.nodes)) {
+    for (const node of jdm.nodes) {
+      if (node.type === 'inputNode' && (!node.content || typeof node.content !== 'object')) {
+        node.content = { fields: [] };
+      }
+    }
+  }
+  return Buffer.from(JSON.stringify(jdm), 'utf8');
 };
 
 // Zen engine instance with loader pulling JDM from SQLite

--- a/index.ts
+++ b/index.ts
@@ -130,8 +130,12 @@ Bun.serve({
         }
         const results = [] as any[];
         for (const part of parts) {
-          const res = await engine.evaluate(key, part);
-          results.push(res.result);
+          try {
+            const res = await engine.evaluate(key, part);
+            results.push(res.result);
+          } catch (err: any) {
+            results.push({ error: err.message || String(err) });
+          }
         }
         return new Response(JSON.stringify(results), {
           headers: { 'Content-Type': 'application/json' }

--- a/index.ts
+++ b/index.ts
@@ -28,15 +28,7 @@ const loadJdm = async (key: string) => {
       .get(id, Number(ver)) as any;
   }
   if (!row) throw new Error(`JDM not found for ${key}`);
-  const jdm = JSON.parse(row.jdm);
-  if (Array.isArray(jdm.nodes)) {
-    for (const node of jdm.nodes) {
-      if (node.type === 'inputNode' && (!node.content || typeof node.content !== 'object')) {
-        node.content = { fields: [] };
-      }
-    }
-  }
-  return Buffer.from(JSON.stringify(jdm), 'utf8');
+  return Buffer.from(row.jdm, 'utf8');
 };
 
 // Zen engine instance with loader pulling JDM from SQLite

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build:editor": "node fix-zen-wasm.js && bun build editor.tsx --outdir public",
+    "build:editor": "node fix-zen-wasm.js && bun build editor.tsx analyze.tsx --outdir public",
     "postinstall": "node fix-zen-wasm.js"
   },
   "devDependencies": {

--- a/public/analyze.html
+++ b/public/analyze.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Zen Analyzer</title>
+  <style>html,body,#root{height:100%;margin:0;}</style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/analyze.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/analyze` endpoint and frontend to generate parts and run them through Zen Engine
- Provide API to evaluate arrays of parts against stored rules
- Document new analyze workflow and build both frontend bundles

## Testing
- `bun run build:editor`

------
https://chatgpt.com/codex/tasks/task_e_68ab9781479083328d4927c2a611f1f5