### PR TITLE
Ensure decision table defaults match JDM UI

### DIFF
--- a/editor.tsx
+++ b/editor.tsx
@@ -89,7 +89,23 @@ const App = () => {
     const res = await fetch(`/rules/${encodeURIComponent(key)}`);
     if (res.ok) {
       const data = await res.json();
-      setGraph(data as any);
+      const graphData = data as any;
+      const baseNode = graphData?.nodes?.find((n: any) => n.id === 'base');
+      if (baseNode && baseNode.content) {
+        baseNode.content = {
+          passThrough: false,
+          inputField: null,
+          outputPath: null,
+          executionMode: 'single',
+          ...baseNode.content
+        };
+        if (Array.isArray(baseNode.content.rules)) {
+          baseNode.content.rules = baseNode.content.rules.map((r: any) =>
+            structuredClone(r)
+          );
+        }
+      }
+      setGraph(graphData);
       alert('Rule loaded');
     } else {
       alert('Rule not found');


### PR DESCRIPTION
## Summary
- Fill decision-table base node content with passThrough, inputField, outputPath and executionMode defaults when loading a rule
- Clone rule rows before the editor assigns `_id`s to keep them mutable

## Testing
- `npm run build:editor`


------
https://chatgpt.com/codex/tasks/task_e_68abef615788833288d767363f8dc1b4