### PR TITLE
Add test-data benchmark page

### DIFF
--- a/benchmark-js.tsx
+++ b/benchmark-js.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const App = () => {
+  const [propCount, setPropCount] = useState(100);
+  const [partCount, setPartCount] = useState(1000);
+  const [logicLen, setLogicLen] = useState(3);
+  const [parts, setParts] = useState<any[]>([]);
+  const [results, setResults] = useState<any | null>(null);
+  const [history, setHistory] = useState<any[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const generate = () => {
+    const arr = Array.from({ length: partCount }, () => {
+      const obj: any = {};
+      for (let i = 0; i < propCount; i++) {
+        obj[`p${i}`] = Math.floor(Math.random() * 1000);
+      }
+      return obj;
+    });
+    setParts(arr);
+    setResults(null);
+    setRunning(false);
+  };
+
+  const run = async () => {
+    setRunning(true);
+    const res = await fetch('/benchmark/arbitrary-js', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parts, iterations: logicLen, propCount })
+    });
+    const data = await res.json();
+    setResults(data);
+    setHistory((h) => [
+      { ts: Date.now(), params: { propCount, partCount, logicLen }, ...data },
+      ...h,
+    ]);
+    setRunning(false);
+  };
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
+      <h2>Zen Benchmark</h2>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Properties per Part:&nbsp;
+          <input
+            type="number"
+            value={propCount}
+            onChange={(e) => {
+              setPropCount(Number(e.target.value));
+              setParts([]);
+              setResults(null);
+            }}
+            style={{ width: '5rem' }}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Part Count:&nbsp;
+          <input
+            type="number"
+            value={partCount}
+            onChange={(e) => {
+              setPartCount(Number(e.target.value));
+              setParts([]);
+              setResults(null);
+            }}
+            style={{ width: '6rem' }}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Logic Length:&nbsp;
+          <input
+            type="number"
+            value={logicLen}
+            onChange={(e) => {
+              setLogicLen(Number(e.target.value));
+              setParts([]);
+              setResults(null);
+            }}
+            style={{ width: '5rem' }}
+          />
+        </label>
+      </div>
+      <p style={{ maxWidth: '40rem' }}>
+        <strong>Logic length</strong> is the number of times a long arithmetic formula is repeated for each
+        property. The same calculation runs in native JavaScript, a Zen expression, and a Zen decision table so
+        the comparisons below reflect equivalent work.
+      </p>
+      <div>
+        <button onClick={generate}>Generate Parts</button>
+      </div>
+      {parts.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <p>
+            Generated {parts.length} parts with {propCount} properties each and logic length {logicLen}.
+          </p>
+          <button onClick={run} disabled={running} style={{ opacity: running ? 0.5 : 1 }}>
+            {running ? 'Running…' : 'Run Benchmark'}
+          </button>
+        </div>
+      )}
+      {results && (
+        <div style={{ marginTop: '1rem' }}>
+          <h4>Latest Result</h4>
+          <p>JS: {results.js.toFixed(3)} ms</p>
+          <p>
+            Expression: {results.expression.toFixed(3)} ms (build {results.build.expression.toFixed(3)} ms,
+            compile {results.compile.expression.toFixed(3)} ms)
+          </p>
+          <p>
+            Table: {results.table.toFixed(3)} ms (build {results.build.table.toFixed(3)} ms, compile{' '}
+            {results.compile.table.toFixed(3)} ms)
+          </p>
+          <p>
+            Remote: build {results.remote.build.toFixed(3)} ms, run {results.remote.run.toFixed(3)} ms
+          </p>
+        </div>
+      )}
+      {history.length > 1 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h4>Previous Runs</h4>
+          <ul>
+            {history.slice(1).map((h) => (
+              <li key={h.ts}>
+                {new Date(h.ts).toLocaleTimeString()}: {h.params.partCount} parts × {h.params.propCount} props, logic {h.params.logicLen}
+                — JS {h.js.toFixed(3)} ms, Expr {h.expression.toFixed(3)} ms, Table {h.table.toFixed(3)} ms, Remote run {h.remote.run.toFixed(3)} ms
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/benchmark-test-data.tsx
+++ b/benchmark-test-data.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const App = () => {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState('');
+  const [count, setCount] = useState(100);
+  const [items, setItems] = useState<any[]>([]);
+  const [results, setResults] = useState<any | null>(null);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    fetch('/test-data')
+      .then((r) => r.json())
+      .then((d) => setFiles(d));
+  }, []);
+
+  const generate = async () => {
+    if (!selected) return;
+    const res = await fetch(`/test-data/${selected}`);
+    const jdm = await res.json();
+    const src = JSON.stringify(jdm);
+    const props = Array.from(new Set([...src.matchAll(/input\.([a-zA-Z0-9_]+)/g)].map((m) => m[1])));
+    const arr = Array.from({ length: count }, () => {
+      const obj: any = {};
+      for (const p of props) obj[p] = Math.floor(Math.random() * 100);
+      return obj;
+    });
+    setItems(arr);
+    setResults(null);
+  };
+
+  const run = async () => {
+    setRunning(true);
+    const res = await fetch('/benchmark/test-data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: selected, parts: items })
+    });
+    const data = await res.json();
+    setResults(data);
+    setRunning(false);
+  };
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
+      <h2>Test Data Benchmark</h2>
+      <div>
+        <select
+          value={selected}
+          onChange={(e) => {
+            setSelected(e.target.value);
+            setItems([]);
+            setResults(null);
+          }}
+        >
+          <option value="">Select JSON…</option>
+          {files.map((f) => (
+            <option key={f} value={f}>
+              {f}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>
+        <label>
+          Items:&nbsp;
+          <input
+            type="number"
+            value={count}
+            onChange={(e) => setCount(Number(e.target.value))}
+            style={{ width: '5rem' }}
+          />
+        </label>
+        <button onClick={generate} disabled={!selected} style={{ marginLeft: '0.5rem' }}>
+          Generate
+        </button>
+      </div>
+      {items.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <p>Generated {items.length} items.</p>
+          <button onClick={run} disabled={running} style={{ opacity: running ? 0.5 : 1 }}>
+            {running ? 'Running…' : 'Run Benchmark'}
+          </button>
+        </div>
+      )}
+      {results && (
+        <div style={{ marginTop: '1rem' }}>
+          <p>JS: {results.js.toFixed(3)} ms</p>
+          <p>Zen: {results.zen.toFixed(3)} ms</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/benchmark.tsx
+++ b/benchmark.tsx
@@ -1,143 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 
-const App = () => {
-  const [propCount, setPropCount] = useState(100);
-  const [partCount, setPartCount] = useState(1000);
-  const [logicLen, setLogicLen] = useState(3);
-  const [parts, setParts] = useState<any[]>([]);
-  const [results, setResults] = useState<any | null>(null);
-  const [history, setHistory] = useState<any[]>([]);
-  const [running, setRunning] = useState(false);
-
-  const generate = () => {
-    const arr = Array.from({ length: partCount }, () => {
-      const obj: any = {};
-      for (let i = 0; i < propCount; i++) {
-        obj[`p${i}`] = Math.floor(Math.random() * 1000);
-      }
-      return obj;
-    });
-    setParts(arr);
-    setResults(null);
-    setRunning(false);
-  };
-
-  const run = async () => {
-    setRunning(true);
-    const res = await fetch('/benchmark/arbitrary-js', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ parts, iterations: logicLen, propCount })
-    });
-    const data = await res.json();
-    setResults(data);
-    setHistory((h) => [
-      { ts: Date.now(), params: { propCount, partCount, logicLen }, ...data },
-      ...h,
-    ]);
-    setRunning(false);
-  };
-
-  return (
-    <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
-      <h2>Zen Benchmark</h2>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Properties per Part:&nbsp;
-          <input
-            type="number"
-            value={propCount}
-            onChange={(e) => {
-              setPropCount(Number(e.target.value));
-              setParts([]);
-              setResults(null);
-            }}
-            style={{ width: '5rem' }}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Part Count:&nbsp;
-          <input
-            type="number"
-            value={partCount}
-            onChange={(e) => {
-              setPartCount(Number(e.target.value));
-              setParts([]);
-              setResults(null);
-            }}
-            style={{ width: '6rem' }}
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label>
-          Logic Length:&nbsp;
-          <input
-            type="number"
-            value={logicLen}
-            onChange={(e) => {
-              setLogicLen(Number(e.target.value));
-              setParts([]);
-              setResults(null);
-            }}
-            style={{ width: '5rem' }}
-          />
-        </label>
-      </div>
-      <p style={{ maxWidth: '40rem' }}>
-        <strong>Logic length</strong> is the number of times a long arithmetic formula is repeated for each
-        property. The same calculation runs in native JavaScript, a Zen expression, and a Zen decision table so
-        the comparisons below reflect equivalent work.
-      </p>
-      <div>
-        <button onClick={generate}>Generate Parts</button>
-      </div>
-      {parts.length > 0 && (
-        <div style={{ marginTop: '1rem' }}>
-          <p>
-            Generated {parts.length} parts with {propCount} properties each and logic length {logicLen}.
-          </p>
-          <button onClick={run} disabled={running} style={{ opacity: running ? 0.5 : 1 }}>
-            {running ? 'Running…' : 'Run Benchmark'}
-          </button>
-        </div>
-      )}
-      {results && (
-        <div style={{ marginTop: '1rem' }}>
-          <h4>Latest Result</h4>
-          <p>JS: {results.js.toFixed(3)} ms</p>
-          <p>
-            Expression: {results.expression.toFixed(3)} ms (build {results.build.expression.toFixed(3)} ms,
-            compile {results.compile.expression.toFixed(3)} ms)
-          </p>
-          <p>
-            Table: {results.table.toFixed(3)} ms (build {results.build.table.toFixed(3)} ms, compile{' '}
-            {results.compile.table.toFixed(3)} ms)
-          </p>
-          <p>
-            Remote: build {results.remote.build.toFixed(3)} ms, run {results.remote.run.toFixed(3)} ms
-          </p>
-        </div>
-      )}
-      {history.length > 1 && (
-        <div style={{ marginTop: '1rem' }}>
-          <h4>Previous Runs</h4>
-          <ul>
-            {history.slice(1).map((h) => (
-              <li key={h.ts}>
-                {new Date(h.ts).toLocaleTimeString()}: {h.params.partCount} parts × {h.params.propCount} props, logic {h.params.logicLen}
-                — JS {h.js.toFixed(3)} ms, Expr {h.expression.toFixed(3)} ms, Table {h.table.toFixed(3)} ms, Remote run {h.remote.run.toFixed(3)} ms
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-};
+const App = () => (
+  <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
+    <h2>Zen Benchmarks</h2>
+    <ul>
+      <li><a href="/benchmark-js">Arbitrary JS Benchmark</a></li>
+      <li><a href="/benchmark-test-data">Test Data Benchmark</a></li>
+    </ul>
+  </div>
+);
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);

--- a/benchmarks/arbitrary-js.ts
+++ b/benchmarks/arbitrary-js.ts
@@ -125,7 +125,8 @@ export async function runBenchmark(
   engine: ZenEngine,
   parts: any[],
   iterations: number,
-  propCount: number
+  propCount: number,
+  _extra?: any
 ) {
   // Build decisions and capture build time
   let start = performance.now();

--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -1,14 +1,17 @@
 import type { ZenEngine } from '@gorules/zen-engine';
 import { runBenchmark as runArbitraryJs } from './arbitrary-js';
+import { runBenchmark as runTestData } from './test-data';
 
 export type BenchmarkRunner = (
   engine: ZenEngine,
   parts: any[],
   iterations: number,
-  propCount: number
+  propCount: number,
+  extra?: any
 ) => Promise<any>;
 
 export const benchmarks: Record<string, BenchmarkRunner> = {
-  'arbitrary-js': runArbitraryJs
+  'arbitrary-js': runArbitraryJs,
+  'test-data': runTestData
   // Additional benchmark strategies can be added here
 };

--- a/benchmarks/test-data.ts
+++ b/benchmarks/test-data.ts
@@ -1,0 +1,146 @@
+import type { ZenEngine } from '@gorules/zen-engine';
+import { promises as fs } from 'fs';
+
+function setByPath(obj: any, path: string, value: any) {
+  const parts = path.split('.');
+  let target = obj;
+  while (parts.length > 1) {
+    const key = parts.shift()!;
+    if (typeof target[key] !== 'object' || target[key] === null) {
+      target[key] = {};
+    }
+    target = target[key];
+  }
+  target[parts[0]] = value;
+}
+
+function buildJsHandler(jdm: any): ((input: any) => Promise<any>) | null {
+  const nodes = new Map(jdm.nodes.map((n: any) => [n.id, n]));
+  const edges = jdm.edges || [];
+  const getNext = (id: string) => edges.find((e: any) => e.sourceId === id)?.targetId;
+  let node = jdm.nodes.find((n: any) => n.type === 'inputNode');
+  if (!node) return null;
+  const steps: any[] = [];
+  while (true) {
+    const nextId = getNext(node.id);
+    if (!nextId) break;
+    node = nodes.get(nextId);
+    if (!node || node.type === 'outputNode') break;
+    steps.push(node);
+  }
+
+  const fns = steps.map((n) => {
+    switch (n.type) {
+      case 'functionNode': {
+        if (typeof n.content === 'string') {
+          try {
+            const fn = new Function(`${n.content}; return handler;`)();
+            return async (input: any) => fn(input, {});
+          } catch {
+            return null;
+          }
+        }
+        return null;
+      }
+      case 'expressionNode': {
+        const exps = n.content?.expressions || [];
+        const compiled = exps.map((e: any) => ({
+          key: e.key,
+          fn: new Function('input', `with(input){ return (${e.value}); }`),
+        }));
+        return async (input: any) => {
+          for (const { key, fn } of compiled) {
+            setByPath(input, key, fn(input));
+          }
+          return input;
+        };
+      }
+      case 'decisionTableNode': {
+        const content = n.content || {};
+        const inputs = content.inputs || [];
+        const outputs = content.outputs || [];
+        const rules = content.rules || [];
+        const compiledRules = rules.map((r: any) => {
+          const conds = inputs.map((inp: any) => {
+            const cond = r[inp.id];
+            if (!cond) return null;
+            const expr = `${inp.field} ${cond}`;
+            return new Function('input', `with(input){ return (${expr}); }`);
+          });
+          const outs = outputs.map((out: any) => {
+            const val = r[out.id];
+            if (val === undefined) return null;
+            const fn = new Function('input', `with(input){ return (${val}); }`);
+            return { key: out.field, fn };
+          }).filter(Boolean);
+          return { conds, outs };
+        });
+        return async (input: any) => {
+          for (const rule of compiledRules) {
+            let match = true;
+            for (const cond of rule.conds) {
+              if (cond && !cond(input)) {
+                match = false;
+                break;
+              }
+            }
+            if (match) {
+              const result: any = {};
+              for (const out of rule.outs) {
+                setByPath(result, out.key, out.fn(input));
+              }
+              return result;
+            }
+          }
+          return {};
+        };
+      }
+      default:
+        return null;
+    }
+  });
+
+  if (fns.some((f) => !f)) return null;
+
+  return async (input: any) => {
+    let ctx = input;
+    for (const fn of fns) {
+      ctx = await fn(ctx);
+    }
+    return ctx;
+  };
+}
+
+export async function runBenchmark(
+  engine: ZenEngine,
+  parts: any[],
+  _iterations: number,
+  _propCount: number,
+  extra: any
+) {
+  const file = extra.file as string;
+  const text = await fs.readFile(`test-data/${file}`, 'utf8');
+  const jdm = JSON.parse(text);
+  const decision = engine.createDecision(jdm);
+  decision.validate();
+
+  const jsHandler = buildJsHandler(jdm);
+
+  let start = performance.now();
+  if (jsHandler) {
+    for (const p of parts) {
+      await jsHandler(p);
+    }
+  }
+  let end = performance.now();
+  const jsTime = end - start;
+
+  start = performance.now();
+  for (const p of parts) {
+    await decision.evaluate(p);
+  }
+  end = performance.now();
+  const zenTime = end - start;
+
+  return { js: jsTime, zen: zenTime };
+}

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import { Database } from 'bun:sqlite';
 import { ZenEngine } from '@gorules/zen-engine';
 import { benchmarks } from './benchmarks';
+import { readdirSync } from 'fs';
 
 // Initialize SQLite database and schema
 const db = new Database('rules.db');
@@ -84,8 +85,24 @@ Bun.serve({
         const file = Bun.file('public/benchmark.html');
         return new Response(file, { headers: { 'Content-Type': 'text/html' } });
       }
+      if (req.method === 'GET' && url.pathname === '/benchmark-js') {
+        const file = Bun.file('public/benchmark-js.html');
+        return new Response(file, { headers: { 'Content-Type': 'text/html' } });
+      }
+      if (req.method === 'GET' && url.pathname === '/benchmark-test-data') {
+        const file = Bun.file('public/benchmark-test-data.html');
+        return new Response(file, { headers: { 'Content-Type': 'text/html' } });
+      }
 
-      if (req.method === 'GET' && (url.pathname === '/benchmark.js' || url.pathname === '/benchmark.css')) {
+      if (
+        req.method === 'GET' &&
+        (url.pathname === '/benchmark.js' ||
+          url.pathname === '/benchmark.css' ||
+          url.pathname === '/benchmark-js.js' ||
+          url.pathname === '/benchmark-js.css' ||
+          url.pathname === '/benchmark-test-data.js' ||
+          url.pathname === '/benchmark-test-data.css')
+      ) {
         const path = `public${url.pathname}`;
         const type = url.pathname.endsWith('.css') ? 'text/css' : 'text/javascript';
         const file = Bun.file(path);
@@ -93,6 +110,23 @@ Bun.serve({
           return new Response(file, { headers: { 'Content-Type': type } });
         }
       }
+
+    // List and serve test-data files
+    if (req.method === 'GET' && url.pathname === '/test-data') {
+      const files = readdirSync('test-data').filter((f) => f.endsWith('.json'));
+      return new Response(JSON.stringify(files), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (req.method === 'GET' && url.pathname.startsWith('/test-data/')) {
+      const name = decodeURIComponent(url.pathname.slice('/test-data/'.length));
+      const file = Bun.file(`test-data/${name}`);
+      if (await file.exists()) {
+        return new Response(file, { headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('Not found', { status: 404 });
+    }
 
     // Publish ruleset
     if (req.method === 'POST' && url.pathname === '/rulesets') {
@@ -186,7 +220,7 @@ Bun.serve({
         if (!Array.isArray(parts) || propCount === 0) {
           return new Response('parts are required', { status: 400 });
         }
-        const result = await runner(engine, parts, iterations, propCount);
+        const result = await runner(engine, parts, iterations, propCount, body);
         return new Response(JSON.stringify(result), {
           headers: { 'Content-Type': 'application/json' }
         });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build:ui": "node fix-zen-wasm.js && bun build editor.tsx analyze.tsx benchmark.tsx --outdir public",
+    "build:ui": "node fix-zen-wasm.js && bun build editor.tsx analyze.tsx benchmark.tsx benchmark-js.tsx benchmark-test-data.tsx --outdir public",
     "postinstall": "node fix-zen-wasm.js",
     "remote": "node remote-engine.js"
   },

--- a/public/benchmark-js.html
+++ b/public/benchmark-js.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Arbitrary JS Benchmark</title>
+  <style>html,body,#root{height:100%;margin:0;}</style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/benchmark-js.js"></script>
+</body>
+</html>

--- a/public/benchmark-test-data.html
+++ b/public/benchmark-test-data.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Test Data Benchmark</title>
+  <style>html,body,#root{height:100%;margin:0;}</style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/benchmark-test-data.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split benchmark UI so /benchmark lists available suites
- add test-data benchmark with JSON selection and generation
- support test-data runner and static serving on backend
- expand native JS conversion to handle expression and decision table nodes for accurate baseline

## Testing
- `bun run build:ui`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2eb436c8332b5f77e1148404546